### PR TITLE
Add .DS_Store to .gitignore 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ output/
 qrc_*.cpp
 TODO
 *.session
+*.DS_STORE


### PR DESCRIPTION
Please add the .DS_Store to the exception list. 

Going to be easier for Mac OS X developers.
